### PR TITLE
RTC - Use cmake fetch content to install google test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,19 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 project(RaytracerChallenge)
 
 set(CMAKE_CXX_STANDARD 14)
 
 include_directories(src)
 
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG release-1.12.1
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
 add_subdirectory(src)
 add_subdirectory(tst)
-add_subdirectory(lib/googletest)


### PR DESCRIPTION
Utilize cmake's `fetchContent` to install google test for project testing